### PR TITLE
Add Benchmark project, and performance tweaks

### DIFF
--- a/ahghee.grpc/Types.cs
+++ b/ahghee.grpc/Types.cs
@@ -40,7 +40,7 @@ namespace Ahghee.Grpc {
             "CgRkYXRhImgKA1RNRBIRCglUaW1lc3RhbXAYASABKAMSKAoITWV0YURhdGEY",
             "AiABKAsyFi5haGdoZWUuZ3JwYy5EYXRhQmxvY2sSJAoERGF0YRgDIAEoCzIW",
             "LmFoZ2hlZS5ncnBjLkRhdGFCbG9jayJKCghLZXlWYWx1ZRIdCgNrZXkYASAB",
-            "KAsyEC5haGdoZWUuZ3JwYy5UTUQSHwoFdmFsdWUYAiADKAsyEC5haGdoZWUu",
+            "KAsyEC5haGdoZWUuZ3JwYy5UTUQSHwoFdmFsdWUYAiABKAsyEC5haGdoZWUu",
             "Z3JwYy5UTUQihwEKBE5vZGUSJQoCaWQYASABKAsyGS5haGdoZWUuZ3JwYy5B",
             "ZGRyZXNzQmxvY2sSLQoJZnJhZ21lbnRzGAIgAygLMhouYWhnaGVlLmdycGMu",
             "TWVtb3J5UG9pbnRlchIpCgphdHRyaWJ1dGVzGAMgAygLMhUuYWhnaGVlLmdy",
@@ -1535,7 +1535,7 @@ namespace Ahghee.Grpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public KeyValue(KeyValue other) : this() {
       Key = other.key_ != null ? other.Key.Clone() : null;
-      value_ = other.value_.Clone();
+      Value = other.value_ != null ? other.Value.Clone() : null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1556,12 +1556,13 @@ namespace Ahghee.Grpc {
 
     /// <summary>Field number for the "value" field.</summary>
     public const int ValueFieldNumber = 2;
-    private static readonly pb::FieldCodec<global::Ahghee.Grpc.TMD> _repeated_value_codec
-        = pb::FieldCodec.ForMessage(18, global::Ahghee.Grpc.TMD.Parser);
-    private readonly pbc::RepeatedField<global::Ahghee.Grpc.TMD> value_ = new pbc::RepeatedField<global::Ahghee.Grpc.TMD>();
+    private global::Ahghee.Grpc.TMD value_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public pbc::RepeatedField<global::Ahghee.Grpc.TMD> Value {
+    public global::Ahghee.Grpc.TMD Value {
       get { return value_; }
+      set {
+        value_ = value;
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1578,7 +1579,7 @@ namespace Ahghee.Grpc {
         return true;
       }
       if (!object.Equals(Key, other.Key)) return false;
-      if(!value_.Equals(other.value_)) return false;
+      if (!object.Equals(Value, other.Value)) return false;
       return true;
     }
 
@@ -1586,7 +1587,7 @@ namespace Ahghee.Grpc {
     public override int GetHashCode() {
       int hash = 1;
       if (key_ != null) hash ^= Key.GetHashCode();
-      hash ^= value_.GetHashCode();
+      if (value_ != null) hash ^= Value.GetHashCode();
       return hash;
     }
 
@@ -1601,7 +1602,10 @@ namespace Ahghee.Grpc {
         output.WriteRawTag(10);
         output.WriteMessage(Key);
       }
-      value_.WriteTo(output, _repeated_value_codec);
+      if (value_ != null) {
+        output.WriteRawTag(18);
+        output.WriteMessage(Value);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1610,7 +1614,9 @@ namespace Ahghee.Grpc {
       if (key_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Key);
       }
-      size += value_.CalculateSize(_repeated_value_codec);
+      if (value_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Value);
+      }
       return size;
     }
 
@@ -1625,7 +1631,12 @@ namespace Ahghee.Grpc {
         }
         Key.MergeFrom(other.Key);
       }
-      value_.Add(other.value_);
+      if (other.value_ != null) {
+        if (value_ == null) {
+          value_ = new global::Ahghee.Grpc.TMD();
+        }
+        Value.MergeFrom(other.Value);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1644,7 +1655,10 @@ namespace Ahghee.Grpc {
             break;
           }
           case 18: {
-            value_.AddEntriesFrom(input, _repeated_value_codec);
+            if (value_ == null) {
+              value_ = new global::Ahghee.Grpc.TMD();
+            }
+            input.ReadMessage(value_);
             break;
           }
         }

--- a/ahghee.grpc/types.proto
+++ b/ahghee.grpc/types.proto
@@ -57,7 +57,7 @@ message TMD {
 
 message KeyValue {
     TMD key = 1;
-    repeated TMD value = 2;
+    TMD value = 2;
 }
 
 message Node {

--- a/ahghee.sln
+++ b/ahghee.sln
@@ -9,8 +9,10 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "core.tests", "core.tests\co
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ahghee.grpc", "ahghee.grpc\ahghee.grpc.csproj", "{D3C7171E-EF87-4F7D-BC7E-CAC5073E7EB0}"
 EndProject
-    Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "report", "report\report.fsproj", "{4A25B0DE-DCB7-4010-B36F-DA92352FAFF0}"
-EndProject
+				Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "report", "report\report.fsproj", "{4A25B0DE-DCB7-4010-B36F-DA92352FAFF0}"
+				EndProject
+				Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "benchmark", "benchmark\benchmark.csproj", "{06CF4BB6-C74D-4FFF-A7F1-AAED8154CFCE}"
+				EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,5 +74,17 @@ Global
 		{4A25B0DE-DCB7-4010-B36F-DA92352FAFF0}.Release|x64.Build.0 = Release|Any CPU
 		{4A25B0DE-DCB7-4010-B36F-DA92352FAFF0}.Release|x86.ActiveCfg = Release|Any CPU
 		{4A25B0DE-DCB7-4010-B36F-DA92352FAFF0}.Release|x86.Build.0 = Release|Any CPU
+		{06CF4BB6-C74D-4FFF-A7F1-AAED8154CFCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06CF4BB6-C74D-4FFF-A7F1-AAED8154CFCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06CF4BB6-C74D-4FFF-A7F1-AAED8154CFCE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{06CF4BB6-C74D-4FFF-A7F1-AAED8154CFCE}.Debug|x64.Build.0 = Debug|Any CPU
+		{06CF4BB6-C74D-4FFF-A7F1-AAED8154CFCE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{06CF4BB6-C74D-4FFF-A7F1-AAED8154CFCE}.Debug|x86.Build.0 = Debug|Any CPU
+		{06CF4BB6-C74D-4FFF-A7F1-AAED8154CFCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{06CF4BB6-C74D-4FFF-A7F1-AAED8154CFCE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{06CF4BB6-C74D-4FFF-A7F1-AAED8154CFCE}.Release|x64.ActiveCfg = Release|Any CPU
+		{06CF4BB6-C74D-4FFF-A7F1-AAED8154CFCE}.Release|x64.Build.0 = Release|Any CPU
+		{06CF4BB6-C74D-4FFF-A7F1-AAED8154CFCE}.Release|x86.ActiveCfg = Release|Any CPU
+		{06CF4BB6-C74D-4FFF-A7F1-AAED8154CFCE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Ahghee.Grpc;
+using benchmark;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes.Columns;
+using BenchmarkDotNet.Running;
+using Google.Protobuf;
+
+namespace benchmark
+{
+    [MinColumn, MaxColumn]
+    public class CreatingNodeEmpty
+    {
+        [Benchmark(Baseline = true)]
+        public Node MkNodeEmpty() => Ahghee.Utils.Node(new AddressBlock(), Array.Empty<KeyValue>());
+
+    }
+
+    [MinColumn, MaxColumn]
+    public class CreatingKeyValue
+    {
+        private static string _graph = "graph1";
+        private static string _id = "12345";
+        private static string _key1 = "name";
+        private static string _value1 = "Austin";
+        private byte[] _value1Bytes;
+        private byte[] _key1Bytes;
+        private ByteString _key1ProtoBytes;
+        private ByteString _value1ProtoBytes;
+
+        public CreatingKeyValue()
+        {
+            _key1Bytes = Encoding.UTF8.GetBytes(_key1);
+            _value1Bytes = Encoding.UTF8.GetBytes(_value1);
+            _key1ProtoBytes = Google.Protobuf.ByteString.CopyFrom(_key1Bytes);
+            _value1ProtoBytes = Google.Protobuf.ByteString.CopyFrom(_value1Bytes);
+        }
+        
+        [Benchmark(Baseline = true)]
+        public KeyValue MkKvListString() {
+            var kv = Ahghee.Utils.PropString(_key1, _value1);
+            return kv;
+        }
+        
+        [Benchmark]
+        public KeyValue MkKvArrayString()
+        {
+            var kv = Ahghee.Utils.PropString(_key1, _value1);
+            return kv;
+        }
+        
+        [Benchmark]
+        public KeyValue MkKvManual1()
+        {
+            var kv = new KeyValue();
+            kv.Key = Ahghee.Utils.TMDAuto(Ahghee.Utils.DBBString(_key1));
+            kv.Value = Ahghee.Utils.TMDAuto(Ahghee.Utils.DBBString(_value1));
+            return kv;
+        }
+        
+        [Benchmark]
+        public KeyValue MkKvManual2()
+        {
+            var kv = new KeyValue();
+            kv.Key = Ahghee.Utils.TMDAuto(Ahghee.Utils.DBB(Ahghee.Utils.MetaBytes(Ahghee.Utils.metaPlainTextUtf8,_key1Bytes)));
+            kv.Value = Ahghee.Utils.TMDAuto(Ahghee.Utils.DBB(Ahghee.Utils.MetaBytes(Ahghee.Utils.metaPlainTextUtf8,_value1Bytes)));
+            return kv;
+        }
+        
+        [Benchmark]
+        public KeyValue MkKvManual3()
+        {
+            var kv = new KeyValue();
+            kv.Key = Ahghee.Utils.TMDAuto(Ahghee.Utils.DBB(Ahghee.Utils.MetaBytesNoCopy(Ahghee.Utils.metaPlainTextUtf8,_key1ProtoBytes)));
+            kv.Value = Ahghee.Utils.TMDAuto(Ahghee.Utils.DBB(Ahghee.Utils.MetaBytesNoCopy(Ahghee.Utils.metaPlainTextUtf8,_value1ProtoBytes)));
+            return kv;
+        }
+    }
+
+    [MinColumn, MaxColumn]
+    public class CreatingTypes
+    {
+        [Benchmark]
+        public DataBlock MkBinaryBlockString() => Ahghee.Utils.DBBString(_key1);
+        
+        [Benchmark]
+        public BinaryBlock MkBinaryBlockEmpty() => new BinaryBlock();
+
+        [Benchmark]
+        public AddressBlock MkAddressBlockEmpty() => new AddressBlock();
+
+        [Benchmark]
+        public DataBlock MkDataBlockEmpty() => new DataBlock();
+
+        [Benchmark]
+        public KeyValue MkKeyValueEmpty() => new KeyValue();
+
+        [Benchmark]
+        public Node MkNodeEmpty() => Ahghee.Utils.Node(new AddressBlock(), Array.Empty<KeyValue>());
+
+        
+        private static string _graph = "graph1";
+        private static string _id = "12345";
+        private static string _key1 = "name";
+        private static string _value1 = "Austin";
+        
+        [Benchmark]
+        public AddressBlock MkIdSimple() {
+            var id = Ahghee.Utils.Id(_graph, _id, Ahghee.Utils.NullMemoryPointer());
+            return id;
+        }
+        
+        [Benchmark]
+        public KeyValue MkKvSimple() {
+            var kv = Ahghee.Utils.PropString(_key1, _value1);
+            return kv;
+        }
+        
+        [Benchmark]
+        public Node MkNodeSimple() {
+            var id = Ahghee.Utils.Id(_graph, _id, Ahghee.Utils.NullMemoryPointer());
+            var kv = Ahghee.Utils.PropString(_key1, _value1);
+            return Ahghee.Utils.Node(id, new List<KeyValue>{kv});
+        }
+    }
+    
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            //var summary0 = BenchmarkRunner.Run<CreatingTypes>();
+            //var summary1 = BenchmarkRunner.Run<CreatingKeyValue>();
+            var summary2 = BenchmarkRunner.Run<CreatingNodeEmpty>();
+        }
+    }
+}

--- a/benchmark/benchmark.csproj
+++ b/benchmark/benchmark.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+    <PackageReference Include="Google.Protobuf" Version="3.5.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ahghee.grpc\ahghee.grpc.csproj" />
+    <ProjectReference Include="..\core\ahghee.fsproj" />
+  </ItemGroup>
+</Project>

--- a/core.tests/Tests.fs
+++ b/core.tests/Tests.fs
@@ -88,7 +88,7 @@ type MyTests(output:ITestOutputHelper) =
         
     [<Fact>]
     member __.``Can create a Pair`` () =
-        let pair = PropString "firstName" [|"Richard"; "Dick"|]
+        let pair = PropString "firstName" "Richard"
         let md = pair.Key.Data
         let success = match md.DataCase with
                         | DataBlock.DataOneofCase.Binary when md.Binary.Metabytes.Type = metaPlainTextUtf8 -> true 
@@ -98,7 +98,7 @@ type MyTests(output:ITestOutputHelper) =
     [<Fact>]
     member __.``Can create a Node`` () =
         let node = Node (ABtoyId "1") 
-                        [| PropString "firstName" [|"Richard"; "Dick"|] |]
+                        [| PropString "firstName" "Richard" |]
     
         let empty = node.Attributes |> Seq.isEmpty
         Assert.True (not empty)
@@ -108,20 +108,21 @@ type MyTests(output:ITestOutputHelper) =
     member __.buildNodes : seq<Node> = 
         let node1 = Node (ABtoyId "1" ) 
                          [|
-                            PropString "firstName" [|"Richard"; "Dick"|] 
-                            PropData "follows" [| DABtoyId "2" |] 
+                            PropString "firstName" "Richard" 
+                            PropData "follows" (DABtoyId "2")
                          |]
                    
         let node2 = Node (ABtoyId "2") 
                          [|
-                            PropString "firstName" [|"Sam"; "Sammy"|] 
-                            PropData "follows" [| DABtoyId "1" |]
+                            PropString "firstName" "Sam"
+                            PropData "follows" (DABtoyId "1" )
                          |]
                    
         let node3 = Node (ABtoyId "3") 
                          [|
-                            PropString "firstName" [|"Jim"|]
-                            PropData "follows" [| DABtoyId "1"; DABtoyId "2" |] 
+                            PropString "firstName" "Jim"
+                            PropData "follows" (DABtoyId "1")
+                            PropData "follows" (DABtoyId "2") 
                          |]
                                       
         [| node1; node2; node3 |]      
@@ -135,13 +136,13 @@ type MyTests(output:ITestOutputHelper) =
         seq { for i in 1 .. nodeCount do 
               yield Node (ABtoyId (i.ToString()) )
                          ([|
-                            PropString "firstName" [|"Austin"|]
-                            PropString "lastName"  [|"Harris"|]
-                            PropString "age"       [|"36"|]
-                            PropString "city"      [|"Boulder"|]
-                            PropString "state"     [|"Colorado"|]
+                            PropString "firstName" ("Austin")
+                            PropString "lastName"  ("Harris")
+                            PropString "age"       ("36")
+                            PropString "city"      ("Boulder")
+                            PropString "state"     ("Colorado")
                          |] |> Seq.append (seq {for j in 0 .. perNodeFollowsCount do 
-                                                yield PropData "follows" [| DABtoyId (seededRandom.Next(nodeCount).ToString()) |]                                                    
+                                                yield PropData "follows" (DABtoyId (seededRandom.Next(nodeCount).ToString()))                                                    
                                                 })
                          
                          )    
@@ -206,11 +207,10 @@ type MyTests(output:ITestOutputHelper) =
         g.Flush() 
         let nodesWithIncomingEdges = g.Nodes 
                                          |> Seq.collect (fun n -> n.Attributes) 
-                                         |> Seq.collect (fun y -> y.Value 
-                                                                  |> Seq.map (fun x -> match x.Data.DataCase with  
-                                                                                        | DataBlock.DataOneofCase.Address -> 
-                                                                                            Some(x.Data.Address) 
-                                                                                        | _ -> None))   
+                                         |> Seq.map (fun y -> 
+                                                            match y.Value.Data.DataCase with  
+                                                            | DataBlock.DataOneofCase.Address -> Some(y.Value.Data.Address) 
+                                                            | _ -> None)   
                                          |> Seq.filter (fun x -> match x with 
                                                                  | Some id -> true 
                                                                  | _ -> false)
@@ -299,7 +299,7 @@ type MyTests(output:ITestOutputHelper) =
                 |> List.sortBy (fun x -> x.Id.Nodeid.Nodeid)
                 |> Seq.map (fun n -> 
                             let valuePointers = n.Attributes
-                                                |> Seq.collect (fun attr -> attr.Value)
+                                                |> Seq.map (fun attr -> attr.Value)
                                                 |> Seq.filter (fun tmd ->
                                                                 match  tmd.Data.DataCase with
                                                                 | DataBlock.DataOneofCase.Address -> true
@@ -380,7 +380,7 @@ type MyTests(output:ITestOutputHelper) =
         for i in 1 .. fragments do
             let fragment = Node (ABtoyId ("TESTID") )
                                                     ([|
-                                                       PropString (sprintf "property-%A" i) [|sprintf "%A" i|]
+                                                       PropString (sprintf "property-%A" i) (sprintf "%A" i)
                                                     |]) 
             let adding = g.Add [fragment]
             adding.Wait()
@@ -444,7 +444,7 @@ type MyTests(output:ITestOutputHelper) =
                                                                               | _ -> String.Empty
                                                                               )  
                                                                                                           
-                                                    _id,key,attr.Value |> List.ofSeq
+                                                    _id,key,attr.Value
                                                  )                                                           
                              )
              |> Seq.sortBy (fun (x,_,_) -> x)
@@ -461,20 +461,20 @@ type MyTests(output:ITestOutputHelper) =
          let attrName = "labelV"
          let actual = __.CollectValues attrName g
          let (_,_,one) = actual |> Seq.head 
-         let time = one.Head.Timestamp                    
+         let time = one.Timestamp                    
          
          let expected = [ 
-                                "1",attrName ,[TMDTime (DBBString "person") time]
-                                "2",attrName ,[TMDTime (DBBString "person") time]
-                                "3",attrName ,[TMDTime (DBBString "software") time]
-                                "4",attrName ,[TMDTime (DBBString "person") time]
-                                "5",attrName ,[TMDTime (DBBString "software") time]
-                                "6",attrName ,[TMDTime (DBBString "person") time] 
+                                "1",attrName ,(TMDTime (DBBString "person") time)
+                                "2",attrName ,(TMDTime (DBBString "person") time)
+                                "3",attrName ,(TMDTime (DBBString "software") time)
+                                "4",attrName ,(TMDTime (DBBString "person") time)
+                                "5",attrName ,(TMDTime (DBBString "software") time)
+                                "6",attrName ,(TMDTime (DBBString "person") time) 
                            ]
                            
          output.WriteLine(sprintf "foundData: %A" actual)
          output.WriteLine(sprintf "expectedData: %A" expected)                           
-         Assert.Equal<string * string * list<TMD>>(expected,actual) 
+         Assert.Equal<string * string * TMD>(expected,actual) 
          
     [<Theory>]
     [<InlineData("mem")>]
@@ -486,16 +486,16 @@ type MyTests(output:ITestOutputHelper) =
          let attrName = "age"
          let actual = __.CollectValues attrName g                                         
          let (_,_,one) = actual |> Seq.head 
-         let time = one.Head.Timestamp
+         let time = one.Timestamp
          let expected = [ 
-                        "1",attrName, [TMDTime (DBBInt 29) time]
-                        "2",attrName, [TMDTime (DBBInt 27) time]
-                        "4",attrName, [TMDTime (DBBInt 32) time]
-                        "6",attrName, [TMDTime (DBBInt 35) time]
+                        "1",attrName, TMDTime (DBBInt 29) time
+                        "2",attrName, TMDTime (DBBInt 27) time
+                        "4",attrName, TMDTime (DBBInt 32) time
+                        "6",attrName, TMDTime (DBBInt 35) time
                         ]
          output.WriteLine(sprintf "foundData: %A" actual)
          output.WriteLine(sprintf "expectedData: %A" expected)
-         Assert.Equal<string * string * list<TMD>>(expected,actual)  
+         Assert.Equal<string * string * TMD>(expected,actual)  
          
     [<Theory>]
     [<InlineData("mem", 0)>]
@@ -514,16 +514,16 @@ type MyTests(output:ITestOutputHelper) =
          let attrName = "age"
          let actual = __.CollectValues attrName g                                         
          let (_,_,one) = actual |> Seq.head 
-         let time = one.Head.Timestamp
+         let time = one.Timestamp
          let expected = [ 
-                        "1",attrName, [TMDTime (DBBInt 29) time]
-                        "2",attrName, [TMDTime (DBBInt 27) time]
-                        "4",attrName, [TMDTime (DBBInt 32) time]
-                        "6",attrName, [TMDTime (DBBInt 35) time]
+                        "1",attrName, TMDTime (DBBInt 29) time
+                        "2",attrName, TMDTime (DBBInt 27) time
+                        "4",attrName, TMDTime (DBBInt 32) time
+                        "6",attrName, TMDTime (DBBInt 35) time
                         ]
          output.WriteLine(sprintf "foundData: %A" actual)
          output.WriteLine(sprintf "expectedData: %A" expected)
-         Assert.Equal<string * string * list<TMD>>(expected,actual)                   
+         Assert.Equal<string * string * TMD>(expected,actual)                   
 
     [<Theory>]
     [<InlineData("mem", 0)>]
@@ -542,16 +542,16 @@ type MyTests(output:ITestOutputHelper) =
          let attrName = "age"
          let actual = __.CollectValues attrName g                                         
          let (_,_,one) = actual |> Seq.head 
-         let time = one.Head.Timestamp
+         let time = one.Timestamp
          let expected = [ 
-                        "1",attrName, [TMDTime (DBBInt 29) time]
-                        "2",attrName, [TMDTime (DBBInt 27) time]
-                        "4",attrName, [TMDTime (DBBInt 32) time]
-                        "6",attrName, [TMDTime (DBBInt 35) time]
+                        "1",attrName, TMDTime (DBBInt 29) time
+                        "2",attrName, TMDTime (DBBInt 27) time
+                        "4",attrName, TMDTime (DBBInt 32) time
+                        "6",attrName, TMDTime (DBBInt 35) time
                         ]
          output.WriteLine(sprintf "foundData: %A" actual)
          output.WriteLine(sprintf "expectedData: %A" expected)
-         Assert.Equal<string * string * list<TMD>>(expected,actual) 
+         Assert.Equal<string * string * TMD>(expected,actual) 
 
     [<Theory>]
     [<InlineData("mem")>]
@@ -562,14 +562,14 @@ type MyTests(output:ITestOutputHelper) =
         let attrName = "out.knows"
         let actual = __.CollectValues attrName g                                         
         let (_,_,one) = actual |> Seq.head 
-        let time = one.Head.Timestamp
+        let time = one.Timestamp
         let expected = [ 
-                    "1",attrName, [TMDTime (DABtoyId "7") time]
-                    "1",attrName, [TMDTime (DABtoyId "8") time]
+                    "1",attrName, TMDTime (DABtoyId "7") time
+                    "1",attrName, TMDTime (DABtoyId "8") time
                     ]
         output.WriteLine(sprintf "foundData: %A" actual)
         output.WriteLine(sprintf "expectedData: %A" expected)
-        Assert.Equal<string * string * list<TMD>>(expected,actual)
+        Assert.Equal<string * string * TMD>(expected,actual)
         
     [<Theory>]
     [<InlineData("mem")>]
@@ -579,16 +579,16 @@ type MyTests(output:ITestOutputHelper) =
         let attrName = "out.created"
         let actual = __.CollectValues attrName g                                         
         let (_,_,one) = actual |> Seq.head 
-        let time = one.Head.Timestamp        
+        let time = one.Timestamp        
         let expected = [ 
-                     "1",attrName, [TMDTime (DABtoyId "9") time]
-                     "4",attrName, [TMDTime (DABtoyId "10") time]
-                     "4",attrName, [TMDTime (DABtoyId "11") time]
-                     "6",attrName, [TMDTime (DABtoyId "12") time]
+                     "1",attrName, TMDTime (DABtoyId "9") time
+                     "4",attrName, TMDTime (DABtoyId "10") time
+                     "4",attrName, TMDTime (DABtoyId "11") time
+                     "6",attrName, TMDTime (DABtoyId "12") time
                      ]
         output.WriteLine(sprintf "foundData: %A" actual)
         output.WriteLine(sprintf "expectedData: %A" expected)
-        Assert.Equal<string * string * list<TMD>>(expected,actual)
+        Assert.Equal<string * string * TMD>(expected,actual)
     
 
     [<Theory>]
@@ -600,23 +600,23 @@ type MyTests(output:ITestOutputHelper) =
         let attrName = "in.knows"
         let actual = __.CollectValues attrName g                                         
         let (_,_,one) = actual |> Seq.head 
-        let time = one.Head.Timestamp
+        let time = one.Timestamp
         let expected = [ 
-                    "2",attrName, [TMDTime (DABtoyId "7") time]
-                    "4",attrName, [TMDTime (DABtoyId "8") time]
+                    "2",attrName, TMDTime (DABtoyId "7") time
+                    "4",attrName, TMDTime (DABtoyId "8") time
                     ]
         output.WriteLine(sprintf "foundData: %A" actual)
         output.WriteLine(sprintf "expectedData: %A" expected)
-        Assert.Equal<string * string * list<TMD>>(expected,actual)
+        Assert.Equal<string * string * TMD>(expected,actual)
         
     [<Theory>]
     [<InlineData("mem")>]
     [<InlineData("file")>] 
     member __.``After load tinkerpop-crew.xml Nodes have 'in.created' Edges`` db =        
-        let sortedByNodeIdEdgeId (data: list<string * string * list<TMD>>) = 
+        let sortedByNodeIdEdgeId (data: list<string * string * TMD>) = 
             data 
             |> List.sortBy (fun (a,b,c) -> 
-                                let h1 = c |> List.head
+                                let h1 = c 
                                 a , match h1.Data.DataCase with 
                                     | DataBlock.DataOneofCase.Address when h1.Data.Address.AddressCase = AddressBlock.AddressOneofCase.Nodeid ->
                                         h1.Data.Address.Nodeid.Nodeid
@@ -629,19 +629,19 @@ type MyTests(output:ITestOutputHelper) =
                     |> sortedByNodeIdEdgeId                                         
         
         let (_,_,one) = actual |> Seq.head 
-        let time = one.Head.Timestamp
+        let time = one.Timestamp
         
         let expected = [ 
-                         "3",attrName, [TMDTime (DABtoyId "9") time]
-                         "5",attrName, [TMDTime (DABtoyId "10") time]
-                         "3",attrName, [TMDTime (DABtoyId "11") time]
-                         "3",attrName, [TMDTime (DABtoyId "12") time]
+                         "3",attrName, TMDTime (DABtoyId "9") time
+                         "5",attrName, TMDTime (DABtoyId "10") time
+                         "3",attrName, TMDTime (DABtoyId "11") time
+                         "3",attrName, TMDTime (DABtoyId "12") time
                        ] 
                        |> sortedByNodeIdEdgeId
                      
         output.WriteLine(sprintf "foundData: %A" actual)
         output.WriteLine(sprintf "expectedData: %A" expected)
-        Assert.Equal<string * string * list<TMD>>(expected,actual)
+        Assert.Equal<string * string * TMD>(expected,actual)
          
     [<Theory>]
     [<InlineData("mem")>]
@@ -651,19 +651,19 @@ type MyTests(output:ITestOutputHelper) =
         let attrName = "labelE"
         let actual = __.CollectValues attrName g                                       
         let (_,_,one) = actual |> Seq.head 
-        let time = one.Head.Timestamp        
+        let time = one.Timestamp        
         let expected = [ 
-                         "7",attrName, [TMDTime (DBBString "knows") time]
-                         "8",attrName, [TMDTime (DBBString "knows") time]
-                         "9",attrName, [TMDTime (DBBString "created") time]
-                         "10",attrName, [TMDTime (DBBString "created") time]
-                         "11",attrName, [TMDTime (DBBString "created") time]
-                         "12",attrName, [TMDTime (DBBString "created") time]
+                         "7",attrName, TMDTime (DBBString "knows") time
+                         "8",attrName, TMDTime (DBBString "knows") time
+                         "9",attrName, TMDTime (DBBString "created") time
+                         "10",attrName, TMDTime (DBBString "created") time
+                         "11",attrName, TMDTime (DBBString "created") time
+                         "12",attrName, TMDTime (DBBString "created") time
                        ] |> List.sortBy (fun (x,_,_) -> x)
                      
         output.WriteLine(sprintf "foundData: %A" actual)
         output.WriteLine(sprintf "expectedData: %A" expected)
-        Assert.Equal<string * string * list<TMD>>(expected,actual)         
+        Assert.Equal<string * string * TMD>(expected,actual)         
          
     [<Theory>]
     [<InlineData("mem")>]

--- a/core/FileStore.fs
+++ b/core/FileStore.fs
@@ -60,8 +60,7 @@ type GrpcFileStore(config:Config) =
     let setTimestamps (node:Node) (nowInt:Int64) =
         for kv in node.Attributes do
             kv.Key.Timestamp <- nowInt
-            for v in kv.Value do
-            v.Timestamp <- nowInt
+            kv.Value.Timestamp <- nowInt
     
     let Flush () =
         let parentTask = Task.Factory.StartNew((fun () ->
@@ -119,7 +118,7 @@ type GrpcFileStore(config:Config) =
                 let mutable finished = false
                 while not finished do
                     let req = 
-                        seq { for i in 0 .. 64 do yield requests() }
+                        seq { for i in 0 .. 256 do yield requests() }
                         |> Seq.collect (fun x -> x ) 
                         |> Seq.map (fun x -> x )
                         |> Seq.groupBy ( fun (i,x) -> i)

--- a/core/Metrics.fs
+++ b/core/Metrics.fs
@@ -243,6 +243,13 @@ module Metrics =
                                 let res = new DefaultSlidingWindowReservoir(1028) 
                                 res :> IReservoir)   
                 )    
+
+        static member AddSizeBytes =
+            new MeterOptions(
+                Context=ContextName,
+                Name="AddSizeBytes", 
+                MeasurementUnit=Unit.Bytes
+                ) 
         
         // Reads
         static member ReadTimer = 
@@ -264,13 +271,10 @@ module Metrics =
                 )           
 
         static member ReadSize =
-            new HistogramOptions(
+            new MeterOptions(
                 Context=ContextName,
                 Name="ReadSize", 
-                MeasurementUnit=Unit.Bytes,
-                Reservoir=(fun () -> 
-                                let res = new DefaultSlidingWindowReservoir(1028) 
-                                res :> IReservoir)   
+                MeasurementUnit=Unit.Bytes 
                 ) 
         
         static member ReadNodeFragmentCount =

--- a/core/Program.fs
+++ b/core/Program.fs
@@ -37,9 +37,9 @@ module Program =
     let buildLotsNodes perNodeFollowsCount =
         // static seed, keeps runs comparable
         let seededRandom = new Random(1337)
-        let fn = PropString "firstName" [|"Austin"|]
-        let ln = PropString "lastName"  [|"Harris"|]
-        let follo i = PropData "follows" [| DABtoyId (seededRandom.Next(i).ToString()) |]
+        let fn = PropString "firstName" "Austin"
+        let ln = PropString "lastName"  "Harris"
+        let follo i = PropData "follows" ( DABtoyId (seededRandom.Next(i).ToString()) )
         
         let pregenStuff =
             seq { for i in 1 .. 2000 do 

--- a/core/TinkerPop.fs
+++ b/core/TinkerPop.fs
@@ -74,7 +74,7 @@ module TinkerPop =
                                 
                                 let kv1 = new KeyValue()
                                 kv1.Key <- TMDAuto (DBBString keyString)
-                                kv1.Value.AddRange [ TMDAuto (DBB (MetaBytes valueMeta valueBytes))]
+                                kv1.Value <- TMDAuto (DBB (MetaBytes valueMeta valueBytes))
                                 kv1
                             )
                             |> Seq.append (edges
@@ -84,7 +84,7 @@ module TinkerPop =
                                                                                          |> Seq.find (fun d -> d.Key = "labelE")
                                                                                          |> (fun d -> "out." + d.String.Value)
                                                                                          ))
-                                                                 [DABtoyId (e.Id.ToString())]                     
+                                                                 (DABtoyId (e.Id.ToString()))                     
                                                          )
                                              ) 
                             |> Seq.append (edges
@@ -94,7 +94,7 @@ module TinkerPop =
                                                                                          |> Seq.find (fun d -> d.Key = "labelE")
                                                                                          |> (fun d -> "in." + d.String.Value)
                                                                                          ))
-                                                                 [DABtoyId (e.Id.ToString())]                     
+                                                                 (DABtoyId (e.Id.ToString()))                     
                                                          )
                                              )                  
                         |> z.Attributes.AddRange
@@ -127,7 +127,7 @@ module TinkerPop =
                                 
                                 let kv1 = new KeyValue()
                                 kv1.Key <- TMDAuto (DBBString keyString)
-                                kv1.Value.AddRange [ TMDAuto (DBB (MetaBytes valueMeta valueBytes))]
+                                kv1.Value <- (MetaBytes valueMeta valueBytes) |> DBB |> TMDAuto
                                 kv1
                             )
                             |> Seq.append (edges
@@ -137,7 +137,7 @@ module TinkerPop =
                                                                                          |> Seq.find (fun d -> d.Key = "labelE")
                                                                                          |> (fun d -> "out." + d.String.Value)
                                                                                          ))
-                                                                [DABtoyId (e.Id.ToString())]                      
+                                                                (DABtoyId (e.Id.ToString()))                  
                                                          )
                                              ) 
                             |> Seq.append (edges
@@ -147,12 +147,12 @@ module TinkerPop =
                                                                                          |> Seq.find (fun d -> d.Key = "labelE")
                                                                                          |> (fun d -> "in." + d.String.Value)
                                                                                          ))
-                                                                [DABtoyId (e.Id.ToString())]
+                                                                (DABtoyId (e.Id.ToString()))
                                                          )
                                              )
                             |> Seq.append ( [ 
-                                                Prop (DBBString "source") [DABtoyId (n.Source.ToString())]
-                                                Prop (DBBString "target") [DABtoyId (n.Target.ToString())]
+                                                Prop (DBBString "source") (DABtoyId (n.Source.ToString()))
+                                                Prop (DBBString "target") (DABtoyId (n.Target.ToString()))
                                             ] ) 
                         |> z.Attributes.AddRange
                         z)

--- a/report/program.fs
+++ b/report/program.fs
@@ -333,8 +333,8 @@ module Program =
             |> Chart.WithLabels (data |> metricLabels (fun data -> "FileStore"))
             |> Chart.WithOptions o
             |> Chart.WithTitle (data |> metricTitle (fun d -> sprintf "%s - %s" (d.Name.Split('|') |> Seq.head) measure ))
-            |> Chart.WithXTitle (data |> metricTitle (fun d -> "Time") )
-            |> Chart.WithYTitle (data |> metricTitle (fun d -> d.RateUnit) )
+            |> Chart.WithXTitle (data |> metricTitle (fun d -> d.RateUnit) )
+            |> Chart.WithYTitle (data |> metricTitle (fun d -> sprintf "%A / %A" d.Unit d.RateUnit) )
 
         let filestoreMeterAddFragmentsMeanRate = 
             let measure = "Mean"
@@ -348,7 +348,7 @@ module Program =
             |> Chart.WithOptions o
             |> Chart.WithTitle (data |> metricTitle (fun d -> sprintf "%s - %s" (d.Name.Split('|') |> Seq.head) measure ))
             |> Chart.WithXTitle (data |> metricTitle (fun d -> d.RateUnit) )
-            |> Chart.WithYTitle (data |> metricTitle (fun d -> d.Unit) )
+            |> Chart.WithYTitle (data |> metricTitle (fun d -> sprintf "%A / %A" d.Unit d.RateUnit) )
             
         let filestoreMeterAddFragmentsTotal = 
             let measure = "Total"
@@ -362,7 +362,7 @@ module Program =
             |> Chart.WithOptions o
             |> Chart.WithTitle (data |> metricTitle (fun d -> sprintf "%s - %s" (d.Name.Split('|') |> Seq.head) measure ))
             |> Chart.WithXTitle (data |> metricTitle (fun d -> d.RateUnit) )
-            |> Chart.WithYTitle (data |> metricTitle (fun d -> d.Unit) )                  
+            |> Chart.WithYTitle (data |> metricTitle (fun d -> sprintf "%A / %A" d.Unit d.RateUnit) )                  
 
         let partitionTimerQueueEmptyWaitTimeMean = 
             let measure = "Mean Duration"
@@ -403,8 +403,8 @@ module Program =
             |> Chart.WithLabels (data |> metricLabels (fun data -> sprintf "%A" data.Tags.PartitionId))
             |> Chart.WithOptions o
             |> Chart.WithTitle (data |> metricTitle (fun d -> sprintf "%s - %s" (d.Name.Split('|') |> Seq.head) measure ))
-            |> Chart.WithXTitle (data |> metricTitle (fun d -> "Time") )
-            |> Chart.WithYTitle (data |> metricTitle (fun d -> d.RateUnit) )            
+            |> Chart.WithXTitle (data |> metricTitle (fun d -> d.RateUnit) )
+            |> Chart.WithYTitle (data |> metricTitle (fun d -> sprintf "%A / %A" d.Unit d.RateUnit) )            
 
               
         let partitionMeterAddFragmentsMean = 
@@ -419,7 +419,7 @@ module Program =
             |> Chart.WithOptions o
             |> Chart.WithTitle (data |> metricTitle (fun d -> sprintf "%s - %s" (d.Name.Split('|') |> Seq.head) measure ))
             |> Chart.WithXTitle (data |> metricTitle (fun d -> d.RateUnit) )
-            |> Chart.WithYTitle (data |> metricTitle (fun d -> d.Unit) )
+            |> Chart.WithYTitle (data |> metricTitle (fun d -> sprintf "%A / %A" d.Unit d.RateUnit) )
 
         let partitionHistAddSizeMean = 
             let measure = "Mean Size Per Call"
@@ -434,6 +434,34 @@ module Program =
             |> Chart.WithTitle (data |> metricTitle (fun d -> sprintf "%s - %s" (d.Name.Split('|') |> Seq.head) measure ))
             |> Chart.WithXTitle (data |> metricTitle (fun d -> "Time") )
             |> Chart.WithYTitle (data |> metricTitle (fun d -> d.Unit) )
+
+        let partitionMeterAddSizeRate = 
+            let measure = "Mean Rate"
+            let data = metricGroups "Partition" (fun c -> c.Meters) (fun m -> m.Name) (fun m -> m.Name.StartsWith "AddSizeBytes") input
+            let o = Options()
+            o.isStacked <- true
+            data
+            |> metricMeasure (fun meter -> decimal meter.MeanRate)
+            |> Chart.SteppedArea
+            |> Chart.WithLabels (data |> metricLabels (fun data -> sprintf "%A" data.Tags.PartitionId))
+            |> Chart.WithOptions o
+            |> Chart.WithTitle (data |> metricTitle (fun d -> sprintf "%s - %s" (d.Name.Split('|') |> Seq.head) measure ))
+            |> Chart.WithXTitle (data |> metricTitle (fun d -> "Time") )
+            |> Chart.WithYTitle (data |> metricTitle (fun d -> sprintf "%s / %s" d.Unit d.RateUnit) )
+            
+        let partitionMeterReadSizeRate = 
+            let measure = "Mean Rate"
+            let data = metricGroups "Partition" (fun c -> c.Meters) (fun m -> m.Name) (fun m -> m.Name.StartsWith "ReadSize") input
+            let o = Options()
+            o.isStacked <- true
+            data
+            |> metricMeasure (fun meter -> decimal meter.MeanRate)
+            |> Chart.SteppedArea
+            |> Chart.WithLabels (data |> metricLabels (fun data -> sprintf "%A" data.Tags.PartitionId))
+            |> Chart.WithOptions o
+            |> Chart.WithTitle (data |> metricTitle (fun d -> sprintf "%s - %s" (d.Name.Split('|') |> Seq.head) measure ))
+            |> Chart.WithXTitle (data |> metricTitle (fun d -> "Time") )
+            |> Chart.WithYTitle (data |> metricTitle (fun d -> sprintf "%s / %s" d.Unit d.RateUnit) )    
 
         let partitionHistAddSizeSum = 
             let measure = "Sum"
@@ -530,8 +558,8 @@ module Program =
             |> Chart.WithLabels (data |> metricLabels (fun data -> sprintf "%A" data.Tags.PartitionId))
             |> Chart.WithOptions o
             |> Chart.WithTitle (data |> metricTitle (fun d -> sprintf "%s - %s" (d.Name.Split('|') |> Seq.head) measure ))
-            |> Chart.WithXTitle (data |> metricTitle (fun d -> "Time") )
-            |> Chart.WithYTitle (data |> metricTitle (fun d -> d.RateUnit) ) 
+            |> Chart.WithXTitle (data |> metricTitle (fun d -> d.RateUnit) )
+            |> Chart.WithYTitle (data |> metricTitle (fun d -> sprintf "%A / %A" d.Unit d.RateUnit) ) 
 
         let partitionTimerFlushFixPointersDurationMean = 
             let measure = "Mean Duration"
@@ -558,8 +586,8 @@ module Program =
             |> Chart.WithLabels (data |> metricLabels (fun data -> sprintf "%A" data.Tags.PartitionId))
             |> Chart.WithOptions o
             |> Chart.WithTitle (data |> metricTitle (fun d -> sprintf "%s - %s" (d.Name.Split('|') |> Seq.head) measure ))
-            |> Chart.WithXTitle (data |> metricTitle (fun d -> "Time") )
-            |> Chart.WithYTitle (data |> metricTitle (fun d -> d.RateUnit) )
+            |> Chart.WithXTitle (data |> metricTitle (fun d -> d.RateUnit) )
+            |> Chart.WithYTitle (data |> metricTitle (fun d -> sprintf "%A / %A" d.Unit d.RateUnit) )
 
         let partitionTimerFlushFragmentLinksDurationMean = 
             let measure = "Mean Duration"
@@ -586,8 +614,8 @@ module Program =
             |> Chart.WithLabels (data |> metricLabels (fun data -> sprintf "%A" data.Tags.PartitionId))
             |> Chart.WithOptions o
             |> Chart.WithTitle (data |> metricTitle (fun d -> sprintf "%s - %s" (d.Name.Split('|') |> Seq.head) measure ))
-            |> Chart.WithXTitle (data |> metricTitle (fun d -> "Time") )
-            |> Chart.WithYTitle (data |> metricTitle (fun d -> d.RateUnit) )
+            |> Chart.WithXTitle (data |> metricTitle (fun d -> d.RateUnit) )
+            |> Chart.WithYTitle (data |> metricTitle (fun d -> sprintf "%A / %A" d.Unit d.RateUnit) )
 
         let partitionTimerReadCallRateMean = 
             let measure = "Mean ms Duration"
@@ -645,8 +673,8 @@ module Program =
             |> Chart.WithLabels (data |> metricLabels (fun data -> sprintf "%A" data.Tags.PartitionId))
             |> Chart.WithOptions o
             |> Chart.WithTitle (data |> metricTitle (fun d -> sprintf "%s - %s" (d.Name.Split('|') |> Seq.head) measure ))
-            |> Chart.WithXTitle (data |> metricTitle (fun d -> "Time") )
-            |> Chart.WithYTitle (data |> metricTitle (fun d -> "Calls - One Minute Rate") )                                
+            |> Chart.WithXTitle (data |> metricTitle (fun d -> d.RateUnit) )
+            |> Chart.WithYTitle (data |> metricTitle (fun d -> sprintf "%A / %A" d.Unit d.RateUnit) )                                
 
         let partitionTimerReadCallNodeFragmentCountMean =  
             let measure = "Histogram 1028 window - Mean Node Fragments per call"
@@ -674,7 +702,7 @@ module Program =
             |> Chart.WithOptions o
             |> Chart.WithTitle (data |> metricTitle (fun d -> sprintf "%s - %s" (d.Name.Split('|') |> Seq.head) measure ))
             |> Chart.WithXTitle (data |> metricTitle (fun d -> "Time") )
-            |> Chart.WithYTitle (data |> metricTitle (fun d -> "Nodes - One Minute Rate") )
+            |> Chart.WithYTitle (data |> metricTitle (fun d -> "Nodes Fragments") )
         
         let partitionTimerReadIOTimeMean =  
             let measure = "Histogram 1028 window - Read IO Time - Mean"
@@ -744,6 +772,8 @@ module Program =
                 partitionMeterAddFragmentsMean
                 partitionHistAddSizeMean
                 partitionHistAddSizeSum
+                partitionMeterAddSizeRate
+                partitionMeterReadSizeRate
                 partitionHistFFPReadSizeMean
                 partitionHistFFPWriteSizeMean
                 partitionHistFFLReadSizeMean


### PR DESCRIPTION
KeyValue no longer is takes multiple values.
Added benchmark project for micro-benchmarks.
Added the AddSizeBytes metric
Minor Perf improvement for creating KeyValues with a string value
Minor Perf improvement when creating a Node with the Node function
Fixed some labels on the report.
Added two new metrics to the report.